### PR TITLE
 Refactor to abstract the core logic and IO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   # ------------------------------------------------------------------------
   # What to build
   # ------------------------------------------------------------------------
-  # - DISABLE_TEST=y
+  - DISABLE_TEST=y
   # - DISABLE_BENCH=y
   # - DISABLE_DOCS=y
   # - DISABLE_SDIST_BUILD=y

--- a/cabal.project
+++ b/cabal.project
@@ -3,17 +3,8 @@ packages: streamly-dom.cabal
 
 source-repository-package
   type: git
-  location: https://github.com/ghcjs/ghcjs-base
-  tag: b8d51f65ae1921b2f031710bf75e17f216de442a
-
-source-repository-package
-  type: git
   location: https://github.com/composewell/streamly
   tag: ffe084ad40ab7e9733d7379e0b726c876d893537
-
-package ghcjs-base
-  tests: False
-  benchmarks: False
 
 package streamly
   tests: False

--- a/cabal.project
+++ b/cabal.project
@@ -4,8 +4,11 @@ packages: streamly-dom.cabal
 source-repository-package
   type: git
   location: https://github.com/composewell/streamly
-  tag: ffe084ad40ab7e9733d7379e0b726c876d893537
+  tag: 0e2bb73d6cad77fe43d4e675b804d17da18a4407
 
 package streamly
   tests: False
   benchmarks: False
+
+package streamly-dom
+  flags: examples

--- a/examples/AcidRain/JSIO.hs
+++ b/examples/AcidRain/JSIO.hs
@@ -1,0 +1,171 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module AcidRain.JSIO
+    ( initConsole
+    , printHealth
+    , printError
+    , userStream
+    )
+where
+
+import Streamly
+import Control.Monad.IO.Class (MonadIO(liftIO))
+
+import Control.Monad (when)
+import Control.Monad.Reader (ask)
+
+import GHCJS.DOM
+import GHCJS.DOM.Types
+import GHCJS.DOM.KeyboardEvent
+import GHCJS.DOM.Document
+import GHCJS.DOM.Element
+import GHCJS.DOM.HTMLInputElement
+import GHCJS.DOM.NonElementParentNode
+import GHCJS.DOM.Node
+import GHCJS.DOM.EventM
+import GHCJS.DOM.GlobalEventHandlers
+
+import qualified Streamly.Internal.Prelude as S
+
+-------------------------------------------------------------------------------
+-- Heading (h1)
+-------------------------------------------------------------------------------
+
+makeHeading :: IO HTMLHeadingElement
+makeHeading = do
+    doc <- currentDocumentUnchecked
+    uncheckedCastTo HTMLHeadingElement <$> do
+        h1 <- createElement doc "h1"
+        setAttribute h1 "id" "heading"
+        setInnerHTML h1 "Hello and Welcome to AcidRain"
+        return h1
+
+-------------------------------------------------------------------------------
+-- Info message (p)
+-------------------------------------------------------------------------------
+
+makeInfo :: IO HTMLParagraphElement
+makeInfo = do
+    doc <- currentDocumentUnchecked
+    uncheckedCastTo HTMLParagraphElement <$> do
+        p <- createElement doc "p"
+        setInnerHTML
+            p $ "Your health is deteriorating due to acid rain,"
+                 ++ " type \"potion\" or \"quit\""
+        return p
+
+-------------------------------------------------------------------------------
+-- Health meter (div)
+-------------------------------------------------------------------------------
+
+-- XXX instead of searching every time we can pass the dom elements directly
+-- via state monad.
+healthStatusDiv :: String
+healthStatusDiv = "healthStatus"
+
+makeHealthStatus :: IO HTMLDivElement
+makeHealthStatus = do
+    doc <- currentDocumentUnchecked
+    uncheckedCastTo HTMLDivElement <$> do
+        primeDiv <- createElement doc "div"
+        setAttribute primeDiv "id" healthStatusDiv
+        return primeDiv
+
+printHealth :: (MonadIO m, ToJSString a) => a -> m ()
+printHealth msg = do
+    doc <- currentDocumentUnchecked
+    healthStatus <-
+        uncheckedCastTo HTMLDivElement <$>
+        getElementByIdUnchecked doc healthStatusDiv
+    setInnerHTML healthStatus msg
+
+-------------------------------------------------------------------------------
+-- Error display (div)
+-------------------------------------------------------------------------------
+
+errorDisplayDiv :: String
+errorDisplayDiv = "errorDisplayDiv"
+
+makeErrorDisplay :: IO HTMLDivElement
+makeErrorDisplay = do
+    doc <- currentDocumentUnchecked
+    uncheckedCastTo HTMLDivElement <$> do
+        primeDiv <- createElement doc "div"
+        setAttribute primeDiv "id" errorDisplayDiv
+        return primeDiv
+
+printError :: (MonadIO m, ToJSString a) => a -> m ()
+printError msg = do
+    doc <- currentDocumentUnchecked
+    el <-
+        uncheckedCastTo HTMLDivElement <$>
+        getElementByIdUnchecked doc errorDisplayDiv
+    setInnerHTML el msg
+
+-------------------------------------------------------------------------------
+-- User input (input)
+-------------------------------------------------------------------------------
+
+commandInput :: String
+commandInput = "commandInput"
+
+makeInput :: IO HTMLInputElement
+makeInput = do
+    doc <- currentDocumentUnchecked
+    uncheckedCastTo HTMLInputElement <$> do
+        inp <- createElement doc "input"
+        setAttribute inp "id" commandInput
+        setAttribute inp "size" "8"
+        return inp
+
+-- | Call the user supplied callback on command input.
+setEventHandler :: (String -> IO ()) -> IO ()
+setEventHandler callback = do
+    doc <- currentDocumentUnchecked
+    el <-
+        uncheckedCastTo HTMLInputElement <$>
+            getElementByIdUnchecked doc commandInput
+    _ <- on el keyUp $ do
+            k <- ask
+            result <- getKey k
+            when (result == "Enter") $ liftIO $ do
+                value <- getValue el
+                callback value
+    return ()
+
+userStream :: MonadAsync m => SerialT m String
+userStream = S.hoist liftIO $ S.fromCallback (setEventHandler)
+
+-------------------------------------------------------------------------------
+-- Combined elements (div)
+-------------------------------------------------------------------------------
+
+-- XXX make childs using monadic actions and append them
+-- appendChildsM_ :: self -> [m node] -> m ()
+
+setupPage :: IO HTMLDivElement
+setupPage = do
+    doc <- currentDocumentUnchecked
+    el <- uncheckedCastTo HTMLDivElement <$> createElement doc "div"
+
+    makeHeading >>= appendChild_ el
+    makeInfo >>= appendChild_ el
+    makeHealthStatus >>= appendChild_ el
+    makeErrorDisplay >>= appendChild_ el
+    makeInput >>= appendChild_ el
+    return el
+
+-------------------------------------------------------------------------------
+-- Document body
+-------------------------------------------------------------------------------
+
+appendToBody :: IsNode node => node -> JSM ()
+appendToBody child = do
+    Just doc <- currentDocument
+    Just body <- getBody doc
+    appendChild_ body child
+
+initConsole :: IO ()
+initConsole = do
+    setupPage >>= appendToBody
+    syncPoint

--- a/examples/AcidRain/StdIO.hs
+++ b/examples/AcidRain/StdIO.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module AcidRain.StdIO
+    ( initConsole
+    , printHealth
+    , printError
+    , userStream
+    )
+where
+
+import Streamly
+import Streamly.Prelude as S
+import Control.Monad.IO.Class (liftIO)
+
+initConsole :: IO ()
+initConsole = return ()
+
+printHealth :: MonadAsync m => String -> m ()
+printHealth = liftIO . putStrLn
+
+printError :: MonadAsync m => String -> m ()
+printError = liftIO . putStrLn
+
+userStream :: MonadAsync m => SerialT m String
+userStream = S.repeatM (liftIO getLine)

--- a/examples/CirclingSquare.hs
+++ b/examples/CirclingSquare.hs
@@ -65,7 +65,7 @@ playCirclingSquare = do
     cref <- newIORef (0,0)
     initTime <- getTime Monotonic
     initDom cref
-    runStream $ asyncly $ constRate 40 $
+    S.drain $ asyncly $ constRate 40 $
               S.repeatM (updateDisplay initTime cref)
 
 main :: JSM ()

--- a/streamly-dom.cabal
+++ b/streamly-dom.cabal
@@ -65,8 +65,11 @@ library
                       -Wnoncanonical-monadfail-instances
 
     build-depends:     base              >= 4.8   &&  < 5
-                     , streamly          >= 0.6   && < 0.7
-                     , ghcjs-dom         >= 0.9   && < 0.10
+                     , streamly          >= 0.7   && < 0.8
+
+  if impl(ghcjs)
+    build-depends:
+        ghcjs-dom     >= 0.9   && < 0.10
 
   if impl(ghc < 8.0)
     build-depends:
@@ -106,15 +109,22 @@ test-suite test
 
 executable AcidRain
   default-language: Haskell2010
-  main-is: AcidRain.hs
   hs-source-dirs: examples
+  main-is: AcidRain.hs
+  if impl(ghcjs)
+      other-modules: AcidRain.JSIO
+  else
+      other-modules: AcidRain.StdIO
+  ghc-options:  -O2 -Wall
   if flag(examples)
     buildable: True
     build-Depends:
         base              >= 4.8   && < 5
-      , ghcjs-dom         >= 0.9   && < 0.10
       , mtl               >= 2.2   && < 3
-      , streamly          >= 0.6   && < 0.7
+      , streamly          >= 0.7   && < 0.8
+    if impl(ghcjs)
+      build-depends:
+          ghcjs-dom       >= 0.9   && < 0.10
   else
     buildable: False
 
@@ -122,6 +132,7 @@ executable CirclingSquare
   default-language: Haskell2010
   main-is: CirclingSquare.hs
   hs-source-dirs: examples
+  ghc-options:  -O2 -Wall
   if flag(examples)
     buildable: True
     build-Depends:
@@ -129,6 +140,6 @@ executable CirclingSquare
       , clock             >= 0.7.1 && < 8
       , ghcjs-dom         >= 0.9   && < 0.10
       , mtl               >= 2.2   && < 3
-      , streamly          >= 0.6   && < 0.7
+      , streamly          >= 0.7   && < 0.8
   else
     buildable: False


### PR DESCRIPTION
The core logic is common and the example is ported to:

1) use console as IO device if compiled with StdIO module
2) use browser as IO device of compiled with JSIO module

This demonstrates that we can write the same example that works for both
console as well as browser.